### PR TITLE
fix: sandbox without loosing document.location context

### DIFF
--- a/browserRunner.js
+++ b/browserRunner.js
@@ -206,6 +206,7 @@ window.addEventListener("load", () => {
     module,
     debug = false,
     config: configSrc,
+    origin,
   } = searchParams;
 
   let testFiles = [];
@@ -253,7 +254,7 @@ window.addEventListener("load", () => {
         testFiles = testFiles.filter(testFile => testFile === fileInPath);
       }
 
-      testSandboxes = testFiles.map(testFile => new TestSandbox(testFile, module, config, debug));
+      testSandboxes = testFiles.map(testFile => new TestSandbox(testFile, module, config, debug, origin));
       testSandboxes.forEach(sandbox => sandbox.register());
 
       console.debug(`Registered tests at ${timediff()}`);

--- a/iframe-entrypoint.html
+++ b/iframe-entrypoint.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Iframe sandbox</title>
+</head>
+
+<body>
+
+</body>

--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   "scripts": {
     "build": "scripts/build",
     "prepare": "scripts/build",
-    "test": "node --experimental-test-coverage ./tests/unit/index.js"
+    "test": "node --experimental-test-coverage ./tests/index.js"
   }
 }

--- a/src/TestSandbox.js
+++ b/src/TestSandbox.js
@@ -1,9 +1,10 @@
 import { loadScript, setImportMap, validateLocalFilePath } from "./util/loader.js";
 import { createRootTestSuite } from "./TestSuite.js";
 
-function injectIframe() {
+function injectIframe(origin) {
   return new Promise(resolve => {
     const iframe = document.createElement('iframe');
+    iframe.src = `${origin}/iframe-entrypoint.html`;
     iframe.addEventListener("load", () => resolve(iframe));
 
     // Hide, but don't set display to 'none' since that would break tests that check offsetWidth in Chrome
@@ -23,11 +24,12 @@ function getQueryParams(filePath) {
 }
 
 export default class TestSandbox {
-  constructor(filePath, isModule, config, debug) {
+  constructor(filePath, isModule, config, debug, origin) {
     this.filePath = filePath;
     this.isModule = isModule;
     this.config = config;
     this.debug = debug;
+    this.origin = origin;
     this.iframe = null;
     this.testSuite = null;
     this.error = null;
@@ -77,7 +79,7 @@ export default class TestSandbox {
     // Append filePath's query params to included modules as well
     const queryPatamSuffix = getQueryParams(filePath);
 
-    return this.loadPromise = injectIframe()
+    return this.loadPromise = injectIframe(this.origin)
       .then(_iframe => {
         this.iframe = iframe = _iframe;
         ({ contentWindow, contentDocument } = iframe);

--- a/test-runner/src/TestRunner.js
+++ b/test-runner/src/TestRunner.js
@@ -209,8 +209,9 @@ export default class TestRunner {
         urlParams.push("module")
       }
     }
-
-    return `${this.httpServerUrl}${getEsmUnitRelativePath()}/runner.html?${urlParams.join("&")}`;
+    const origin = `${this.httpServerUrl}${getEsmUnitRelativePath()}`;
+    urlParams.push(`origin=${encodeURIComponent(origin)}`);
+    return `${origin}/runner.html?${urlParams.join("&")}`;
   }
 
   async runTests() {

--- a/tests/esm-unit.integration.config.cjs
+++ b/tests/esm-unit.integration.config.cjs
@@ -1,0 +1,12 @@
+/* global require module */
+
+module.exports = {
+  testFiles: ["src/**/*.test.js", "src/**/*.spec.js"],
+  importMap: {
+    imports: {
+      "esm-unit/": "/",
+    },
+  },
+  module: true,
+  testFiles: ["tests/integration/*.test.js"],
+};

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,0 +1,30 @@
+/* node:coverage disable */
+import { runTests } from "../index.js";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+await import("./unit/assert.test.js");
+await import("./unit/util/loader.test.js");
+
+async function runIntegrationTests() {
+  try {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const options = {
+      debug: false,
+      browsers: ["chrome"],
+      headless: true,
+      config: join(__dirname, "./esm-unit.integration.config.cjs"),
+      remote: false,
+      verbose: false,
+      watch: false,
+      coverage: false,
+    };
+    const { success } = await runTests(options);
+    process.exit(success ? 0 : 1);
+  } catch (err) {
+    console.error(err.stack || "Error: " + err);
+    process.exit(1);
+  }
+}
+
+runIntegrationTests();

--- a/tests/integration/test-context.test.js
+++ b/tests/integration/test-context.test.js
@@ -1,0 +1,10 @@
+import { describe, test, assert } from "esm-unit/test-api.js";
+
+describe("test-context", () => {
+  /**
+   *  This is needed if anything dependant on ServiceWorker is used inside the test
+   */
+  test("it should have document.location.host defined", () => {
+    assert.equal("localhost:17777", document.location.host);
+  });
+});

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -1,4 +1,0 @@
-/* node:coverage disable */
-
-await import('./assert.test.js');
-await import('./util/loader.test.js');


### PR DESCRIPTION
## What's changing, and why

A bug was found if tested code contains ServiceWorker

### Steps to reproduce
1. Have a test which contains ServiceWorker
    1. ServiceWorker may be either in the tested or test code. For example, I was using [MSW mocking library](https://mswjs.io/docs/integrations/browser).
1. Run tests

### Expected
ServiceWorker to register.

### Actual
- `"InvalidStateError: Failed to get ServiceWorkerRegistration objects: The document is in an invalid state"` in Chrome
- `Script origin does not match the registering client's origin` in Safari

### Technical details

This problem happens, because `TestSandbox` abstraction executes each individual test in a new iframe to isolate those. This iframe is created without the `src` property, so all the tests are executed in the empty page context: if `document.location` is debugged, it appears as `about:blank` without any hostname.

This is a problem to register a ServiceWorker, and also it may bring incompatibility issues to other browser APIs.

A proposed way to fix it:
- Distribute an additional empty `iframe-entrypoint.html` file
- Make iframe to be rendered inside this empty html file being served by the HTTPs server already used in the project

This way the test is executed inside a secure HTTPs context. ServiceWorkers are tested to behave properly, MSW mocks fine.


## What else might be impacted?

This is a relatively small change in terms of production code, but it also brings a change to the testing infrastructure of the project.

Previously only unit tests has been present in the project.

This PR adds a new `integration` tests folder, just because I believe the best way to implement such a test is by integration test. Such a test may bring additional confidence this functionality is not broken in the future releases especially if internal implementation (e.g. changing iframe isolation to any other) is changed.

This integration test uses `esm-unit` to run `esm-unit` tests. And nevertheless I personally love the romance of such a quine, I also admit this idea may be different from the project's ideology and roadmap. And also I confirm that the tests run-time has been dramatically increased.

So please provide me with an input about this change, I see 3 different possibilities:
1. integration tests are kept together with unit ones, everything stays like in this PR
2. unit ones are rewritten to the new integration structure, in this case `npm test` can be rewritten to run `bin/esm-unit` to better match real-world usage and the tool itself may be used to collect coverage itself. I am enthusiastic to do such a migration.
3. integration tests are removed and this test is rewritten in unit-test fashion


## Checklist

[x] Tested with `--debug`
[x] Tested with headless command line
[x] Documentation (function/class docs, comments, etc.)
